### PR TITLE
Remove --autoplay and --pause short options

### DIFF
--- a/docs/oshu.1.in
+++ b/docs/oshu.1.in
@@ -29,10 +29,10 @@ twice and you'll get verbose debugging messages.
 \fB\-h, \-\-help\fR
 Show a brief help message.
 .TP
-\fB\-h, \-\-autoplay\fR
+\fB\-\-autoplay\fR
 Perform a perfect run on the beatmap without any user interaction.
 .TP
-\fB\-h, \-\-pause\fR
+\fB\-\-pause\fR
 Start the game in a paused state. Might be useful when you're starting the game
 from a terminal as you won't be holding your mouse when the game starts.
 


### PR DESCRIPTION
From oshu.c it looks like there is no short options for ``--autoplay`` and ``--pause``.