### PR TITLE
stream.cc: Apply termux patch for ffmpeg-7

### DIFF
--- a/lib/audio/stream.cc
+++ b/lib/audio/stream.cc
@@ -115,13 +115,13 @@ static int next_frame(oshu::stream *stream)
  */
 static int convert_frame(struct SwrContext *converter, AVFrame *frame, int index, float *samples, int wanted)
 {
-	const uint8_t *data[frame->channels];
+	const uint8_t *data[channels];
 	int sample_size = av_get_bytes_per_sample((AVSampleFormat) frame->format);
 	if (av_sample_fmt_is_planar((AVSampleFormat) frame->format)) {
-		for (int c = 0; c < frame->channels; ++c)
+		for (int c = 0; c < channels; ++c)
 			data[c] = frame->data[c] + index * sample_size;
 	} else {
-		data[0] = frame->data[0] + index * sample_size * frame->channels;
+		data[0] = frame->data[0] + index * sample_size * channels;
 	}
 
 	int left = frame->nb_samples - index;
@@ -236,8 +236,7 @@ static int open_decoder(oshu::stream *stream)
 		oshu_log_error("error opening the codec");
 		goto fail;
 	}
-	if (!stream->decoder->channel_layout)
-		stream->decoder->channel_layout = av_get_default_channel_layout(stream->decoder->channels);
+
 	stream->frame = av_frame_alloc();
 	if (stream->frame == NULL) {
 		oshu_log_error("could not allocate the codec frame");
@@ -257,19 +256,24 @@ fail:
  */
 static int open_converter(oshu::stream *stream)
 {
+	AVChannelLayout input_channel_layout, output_channel_layout;
+	av_channel_layout_default(&input_channel_layout, channels);
+	av_channel_layout_default(&output_channel_layout, channels);
 	assert (channels == 2);
-	stream->converter = swr_alloc_set_opts(
-		stream->converter,
+	swr_alloc_set_opts2(
+		&stream->converter,
 		/* output */
-		AV_CH_LAYOUT_STEREO,
+		&output_channel_layout,
 		AV_SAMPLE_FMT_FLT,
 		stream->sample_rate,
 		/* input */
-		stream->decoder->channel_layout,
+		&input_channel_layout,
 		stream->decoder->sample_fmt,
 		stream->decoder->sample_rate,
 		0, NULL
 	);
+	av_channel_layout_uninit(&input_channel_layout);
+	av_channel_layout_uninit(&output_channel_layout);
 	if (!stream->converter) {
 		oshu_log_error("error allocating the audio resampler");
 		return -1;


### PR DESCRIPTION
> Replace the use of `frame->channels` with the hardcoded `channels`
> global variable the app has, and replace the use of `swr_alloc_set_opts()`
> with calls to `av_channel_layout_default()` and `swr_alloc_set_opts2()`
https://github.com/termux/termux-packages/blob/d5dd1c9e6850a544e9aebe5ca7ef51611659aefe/x11-packages/oshu/ffmpeg7.patch
