### PR TITLE
cmake: bump minimum required to 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.25)
 
 project(
 	oshu

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ First of all, make sure you have the required dependencies. These things are so
 common that I may assure you they're in your distribution's official
 repositories.
 
-- CMake 3.9,
+- CMake 3.25,
 - a C++14 compiler,
 - pkg-config,
 - SDL2 ≥ 2.0.5,


### PR DESCRIPTION
CMake is deprecating <3.10
Put it to 3.25 as it is what Debian oldstable got and so unlikely to be too recent for anyone.

Downstream bug: https://bugs.gentoo.org/964778
